### PR TITLE
define PKG_CHECK_VAR if it doesn't exist

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Tobias Jakobsson <tobias@fotobias.se>
 PJ Fancher <pj@digitalbrands.com>
 Sugandi <gandikun@live.com>
 Lucas Luitjes <lucas@mindrules.net>
+Rick van de Loo <rickvandeloo@gmail.com>

--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,25 @@ AC_CHECK_PROGS(PYTHON,
 	[python python3 python2],
 	[AC_MSG_ERROR([Python is needed to build this vmod.]) ])
 
+# backwards compat with older pkg-config 
+# source: https://github.com/varnish/libvmod-example/pull/18
+# - pull in AC_DEFUN from pkg.m4
+m4_ifndef([PKG_CHECK_VAR], [
+# PKG_CHECK_VAR(VARIABLE, MODULE, CONFIG-VARIABLE,
+# [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# -------------------------------------------
+# Retrieves the value of the pkg-config variable for the given module.
+AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])# PKG_CHECK_VAR
+])
+
 # read Varnis's pkg-config
 PKG_CHECK_MODULES([libvarnishapi], [varnishapi])
 PKG_CHECK_VAR([LIBVARNISHAPI_PREFIX], [varnishapi], [prefix])


### PR DESCRIPTION
avoids problems with outdated versions of pkg-config

See https://github.com/varnish/libvmod-example/pull/18
and https://github.com/varnish/libvmod-example/issues/19

```
pkg-config --version
0.26
```

before:
```
./autogen.sh && ./configure
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
libtoolize: copying file `m4/libtool.m4'
libtoolize: copying file `m4/ltoptions.m4'
libtoolize: copying file `m4/ltsugar.m4'
libtoolize: copying file `m4/ltversion.m4'
libtoolize: copying file `m4/lt~obsolete.m4'
configure.ac:96: error: possibly undefined macro: PKG_CHECK_VAR
```

after:
```
./autogen.sh && ./configure
PKG_CONFIG_PATH="/usr/lib/pkgconfig/" ./autogen.sh 
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
libtoolize: copying file `m4/libtool.m4'
libtoolize: copying file `m4/ltoptions.m4'
libtoolize: copying file `m4/ltsugar.m4'
libtoolize: copying file `m4/ltversion.m4'
libtoolize: copying file `m4/lt~obsolete.m4'
checking build system type... x86_64-unknown-linux-gnu
...
```